### PR TITLE
Refresh the context before every transformation between binary and JSON.

### DIFF
--- a/app/src/androidTest/java/one/block/testeosiojavaabieos/AbiEosInstrumentedTest.java
+++ b/app/src/androidTest/java/one/block/testeosiojavaabieos/AbiEosInstrumentedTest.java
@@ -6,6 +6,7 @@ import one.block.eosiojavaabieosserializationprovider.AbiEos;
 import one.block.eosiojavaabieosserializationprovider.AbiEosContextError;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,15 +21,10 @@ import static org.junit.Assert.*;
 @RunWith(AndroidJUnit4.class)
 public class AbiEosInstrumentedTest {
 
-    private AbiEos abieos = null;
+    private static AbiEos abieos = new AbiEos();
 
-    @Before
-    public void setUp() {
-        abieos = new AbiEos();
-    }
-
-    @After
-    public void tearDown() {
+    @AfterClass
+    public static void endTearDown() {
         abieos.destroyContext();
         abieos = null;
     }

--- a/eosiojavaabieos/src/main/java/one/block/eosiojavaabieosserializationprovider/AbiEos.java
+++ b/eosiojavaabieos/src/main/java/one/block/eosiojavaabieosserializationprovider/AbiEos.java
@@ -98,7 +98,9 @@ public class AbiEos {
                             @Nullable String abi,
                             boolean isReorderable) throws EosioError {
 
-        if (null == context) throw new AbiEosContextError("Null context!  Has destroyContext() already been called?");
+        // refreshContext() will throw an error if it can't create the context so we don't need
+        // to check it explicitly before this.
+        refreshContext();
 
         long contract64 = stringToName64(contract);
 
@@ -166,7 +168,9 @@ public class AbiEos {
                             @NotNull String hex,
                             @Nullable String abi) throws EosioError {
 
-        if (null == context) throw new AbiEosContextError("Null context!  Has destroyContext() already been called?");
+        // refreshContext() will throw an error if it can't create the context so we don't need
+        // to check it explicitly before this.
+        refreshContext();
 
         long contract64 = stringToName64(contract);
         String abiJsonString = getAbiJsonString(contract, name, abi);
@@ -194,6 +198,14 @@ public class AbiEos {
 
         return jsonStr;
 
+    }
+
+    private void refreshContext() {
+        destroyContext();
+        context = create();
+        if (null == context) {
+            throw new AbiEosContextError("Could not create abieos context.");
+        }
     }
 
     @NotNull


### PR DESCRIPTION
Update unit tests to reflect that AbiEos() does not need to be created every time anymore.